### PR TITLE
Fix script bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,10 @@ Partially yes. Because "Resign Page" can be split via <code>Page Break</code> bl
 
 ## Changelog
 
+### 2.0.1
+
+- Fix script bug of Resign Button block in case the button url is empty.
+
 ### 2.0.0
 
 - **Notice** PHP requirements is now PHP 7.2 and over.

--- a/src/NeverLetMeGo/ResignButton.php
+++ b/src/NeverLetMeGo/ResignButton.php
@@ -28,7 +28,7 @@ class ResignButton extends Application {
 	 * @return void
 	 */
 	public function register_blocks() {
-		wp_localize_script( 'nlmg-resing-block-helper', 'NlmgRedirect', [
+		wp_localize_script( 'nlmg-resign-block-helper', 'NlmgRedirect', [
 			'url' => home_url(),
 		] );
 		register_block_type( 'nlmg/resign-block', [


### PR DESCRIPTION
Fix: In Resign Button block, if url of the button is empty, JavaScript raises error.